### PR TITLE
Partial fix for missing file crash.

### DIFF
--- a/AssemblyWatcher/AssemblyWatcherCommand.cs
+++ b/AssemblyWatcher/AssemblyWatcherCommand.cs
@@ -87,7 +87,8 @@ namespace AssemblyWatcher.Plugin
         {
             foreach (var assembly in MainWindow.Instance.CurrentAssemblyList.GetAssemblies())
             {
-                StartWatchingAssembly(assembly.FileName);
+                if (File.Exists(assembly.FileName))
+                    StartWatchingAssembly(assembly.FileName);
             }
         }
 


### PR DESCRIPTION
This skips the missing file. So, the user still needs to F5.
I see it as a fix when able to detect the file back without F5.
